### PR TITLE
Add regex to --replace-src-path

### DIFF
--- a/src/filter.cc
+++ b/src/filter.cc
@@ -6,6 +6,7 @@
 #include <stdlib.h>
 #include <string>
 #include <vector>
+#include <regex>
 
 using namespace kcov;
 
@@ -199,19 +200,12 @@ public:
 	std::string mangleSourcePath(const std::string &path)
 	{
 		std::string filename = get_real_path(path);
-
 		if (m_origRoot.length() > 0 && m_newRoot.length() > 0)
 		{
-			std::string path = filename;
-			size_t index = path.find(m_origRoot);
-
-			if (index != std::string::npos)
-			{
-				path.replace(index, m_origRoot.length(), m_newRoot);
-				filename = get_real_path(path);
-			}
+			std::regex regexRoot(m_origRoot);
+			filename = get_real_path(regex_replace (filename,regexRoot,m_newRoot));
+			
 		}
-
 		return filename;
 	}
 


### PR DESCRIPTION
This change allows to pass a regex to the --replace-src-path argument. This is useful, for example, when the build directory of the tested binary is a randomly created temp directory. Note that after the change the older usage of the parameter is still valid

Usage example:
kcov --replace-src-path=([^ ]*)/build_dir/src:/my_src_dir/"